### PR TITLE
Add web-based MIDI note editor with layer toggles

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,166 @@
+const canvas = document.getElementById('pianoRoll');
+const ctx = canvas.getContext('2d');
+
+const pitchLayer = document.getElementById('pitchLayer');
+const durationLayer = document.getElementById('durationLayer');
+const loudnessLayer = document.getElementById('loudnessLayer');
+const velocitySlider = document.getElementById('velocity');
+const playBtn = document.getElementById('play');
+
+const noteHeight = 10; // pixels per semitone
+const maxPitch = 84;
+const minPitch = 24;
+const defaultPitch = 60;
+const defaultWidth = 40; // px
+const defaultVelocity = 100;
+const timePerPixel = 0.01; // seconds per pixel
+
+const pitchCount = maxPitch - minPitch + 1;
+canvas.height = pitchCount * noteHeight;
+
+function pitchToY(pitch) {
+  return (maxPitch - pitch) * noteHeight;
+}
+function yToPitch(y) {
+  return maxPitch - Math.floor(y / noteHeight);
+}
+
+let notes = [];
+let currentNote = null;
+let selectedNote = null;
+let mode = null; // 'new', 'move', 'resize'
+let dragOffsetX = 0;
+let dragOffsetY = 0;
+
+canvas.addEventListener('mousedown', (e) => {
+  const { x, y } = getMousePos(e);
+  currentNote = getNoteAt(x, y);
+  if (currentNote) {
+    selectNote(currentNote);
+    if (x > currentNote.x + currentNote.width - 5 && durationLayer.checked) {
+      mode = 'resize';
+    } else {
+      mode = 'move';
+      dragOffsetX = x - currentNote.x;
+      dragOffsetY = y - pitchToY(currentNote.pitch);
+    }
+  } else {
+    mode = 'new';
+    const pitch = yToPitch(y);
+    currentNote = {
+      x,
+      width: 1,
+      pitch,
+      velocity: defaultVelocity
+    };
+    notes.push(currentNote);
+    selectNote(currentNote);
+  }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+  if (!currentNote) return;
+  const { x, y } = getMousePos(e);
+  if (mode === 'new' || mode === 'resize') {
+    if (durationLayer.checked) {
+      currentNote.width = Math.max(1, x - currentNote.x);
+    }
+  } else if (mode === 'move') {
+    currentNote.x = x - dragOffsetX;
+    if (pitchLayer.checked) {
+      currentNote.pitch = yToPitch(y - dragOffsetY);
+    }
+  }
+  draw();
+});
+
+canvas.addEventListener('mouseup', () => {
+  currentNote = null;
+  mode = null;
+});
+
+velocitySlider.addEventListener('input', () => {
+  if (selectedNote && loudnessLayer.checked) {
+    selectedNote.velocity = parseInt(velocitySlider.value, 10);
+    draw();
+  }
+});
+
+pitchLayer.addEventListener('change', updateControls);
+durationLayer.addEventListener('change', updateControls);
+loudnessLayer.addEventListener('change', updateControls);
+
+playBtn.addEventListener('click', playNotes);
+
+function updateControls() {
+  velocitySlider.disabled = !loudnessLayer.checked || !selectedNote;
+  draw();
+}
+
+function selectNote(note) {
+  selectedNote = note;
+  if (note && loudnessLayer.checked) {
+    velocitySlider.value = note.velocity;
+  }
+  updateControls();
+}
+
+function getMousePos(e) {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top
+  };
+}
+
+function getNoteAt(x, y) {
+  return notes.find(n => x >= n.x && x <= n.x + (durationLayer.checked ? n.width : defaultWidth) && y >= pitchToY(n.pitch) && y <= pitchToY(n.pitch) + noteHeight);
+}
+
+function drawGrid() {
+  ctx.strokeStyle = '#eee';
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= canvas.height; i += noteHeight) {
+    ctx.beginPath();
+    ctx.moveTo(0, i);
+    ctx.lineTo(canvas.width, i);
+    ctx.stroke();
+  }
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawGrid();
+  for (const note of notes) {
+    const y = pitchLayer.checked ? pitchToY(note.pitch) : pitchToY(defaultPitch);
+    const width = durationLayer.checked ? note.width : defaultWidth;
+    const velocity = loudnessLayer.checked ? note.velocity : defaultVelocity;
+    const color = `hsl(200, 100%, ${100 - (velocity / 127) * 50}%)`;
+    ctx.fillStyle = color;
+    ctx.fillRect(note.x, y, width, noteHeight - 1);
+    if (note === selectedNote) {
+      ctx.strokeStyle = '#000';
+      ctx.strokeRect(note.x, y, width, noteHeight - 1);
+    }
+  }
+}
+
+draw();
+
+function playNotes() {
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  const now = audioCtx.currentTime;
+  for (const note of notes) {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    const pitch = pitchLayer.checked ? note.pitch : defaultPitch;
+    const duration = (durationLayer.checked ? note.width : defaultWidth) * timePerPixel;
+    const velocity = (loudnessLayer.checked ? note.velocity : defaultVelocity) / 127;
+    const freq = 440 * Math.pow(2, (pitch - 69) / 12);
+    osc.frequency.setValueAtTime(freq, now + note.x * timePerPixel);
+    gain.gain.value = velocity;
+    osc.connect(gain).connect(audioCtx.destination);
+    osc.start(now + note.x * timePerPixel);
+    osc.stop(now + note.x * timePerPixel + duration);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>MIDI Note Grid</title>
+  <style>
+    canvas {
+      border: 1px solid #ccc;
+      display: block;
+    }
+    #controls {
+      margin-top: 8px;
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="pianoRoll" width="800" height="600"></canvas>
+  <div id="controls">
+    <label><input type="checkbox" id="pitchLayer" checked /> Pitch</label>
+    <label><input type="checkbox" id="durationLayer" checked /> Duration</label>
+    <label><input type="checkbox" id="loudnessLayer" checked /> Loudness</label>
+    <label style="margin-left:10px;">Loudness
+      <input type="range" id="velocity" min="1" max="127" value="100" />
+    </label>
+    <button id="play">Play</button>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build HTML canvas piano-roll interface for drawing MIDI-style notes
- Support editing pitch, duration, and loudness with checkbox layers and velocity slider
- Play back notes using Web Audio API with defaults when layers disabled

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16676e168832083c43c73eae4cc5a