### PR TITLE
Ensure AudioContext resumes before playback

### DIFF
--- a/app.js
+++ b/app.js
@@ -258,13 +258,15 @@ function togglePlay() {
 function startPlayback() {
   if (notes.length === 0) return;
   audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-  isPlaying = true;
-  playBtn.textContent = '⏸';
-  playbackStart = audioCtx.currentTime - playheadOffset;
-  notes.forEach(n => n.started = false);
-  lastBeat = Math.floor(playheadOffset / beatDuration);
-  endTime = notes.reduce((m, n) => Math.max(m, n.x + (durationLayer.checked ? n.width : defaultWidth)), 0) * timePerPixel;
-  animate();
+  audioCtx.resume().then(() => {
+    isPlaying = true;
+    playBtn.textContent = '⏸';
+    playbackStart = audioCtx.currentTime - playheadOffset;
+    notes.forEach(n => n.started = false);
+    lastBeat = Math.floor(playheadOffset / beatDuration);
+    endTime = notes.reduce((m, n) => Math.max(m, n.x + (durationLayer.checked ? n.width : defaultWidth)), 0) * timePerPixel;
+    animate();
+  });
 }
 
 function pausePlayback() {


### PR DESCRIPTION
## Summary
- Resume `AudioContext` before initiating playback so `currentTime` advances and audio starts reliably.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16e9c8a4c8320a2c4187db77ed762