### PR TITLE
Enable note deletion on double click

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,6 +79,19 @@ canvas.addEventListener('mouseup', () => {
   mode = null;
 });
 
+canvas.addEventListener('dblclick', (e) => {
+  const { x, y } = getMousePos(e);
+  const note = getNoteAt(x, y);
+  if (note) {
+    notes.splice(notes.indexOf(note), 1);
+    if (selectedNote === note) {
+      selectNote(null);
+    } else {
+      draw();
+    }
+  }
+});
+
 velocitySlider.addEventListener('input', () => {
   if (selectedNote && loudnessLayer.checked) {
     selectedNote.velocity = parseInt(velocitySlider.value, 10);


### PR DESCRIPTION
## Summary
- Allow removing notes by double-clicking them on the piano roll canvas.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c17eb9f1848320afce3e7e2d04b856