### PR TITLE
Add vertical beat grid lines

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,6 +154,13 @@ function drawGrid() {
     ctx.lineTo(canvas.width, i);
     ctx.stroke();
   }
+  const beatWidth = 0.5 / baseTimePerPixel; // pixels per beat at current scale
+  for (let x = 0; x <= canvas.width; x += beatWidth) {
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, canvas.height);
+    ctx.stroke();
+  }
 }
 
 function draw() {


### PR DESCRIPTION
## Summary
- Draw vertical grid lines at beat intervals to visualize tempo beats.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18a3599608320829f74521538e49e