### PR TITLE
Revert discrete time toggle for note durations

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,7 +4,6 @@ const ctx = canvas.getContext('2d');
 const pitchLayer = document.getElementById('pitchLayer');
 const durationLayer = document.getElementById('durationLayer');
 const loudnessLayer = document.getElementById('loudnessLayer');
-const discreteTime = document.getElementById('discreteTime');
 const velocitySlider = document.getElementById('velocity');
 const tempoSlider = document.getElementById('tempo');
 const playBtn = document.getElementById('play');
@@ -64,10 +63,9 @@ canvas.addEventListener('mousedown', (e) => {
   } else {
     mode = 'new';
     const pitch = yToPitch(y);
-    const initialWidth = discreteTime.checked ? currentBeatWidth / 4 : 1;
     currentNote = {
       x,
-      width: initialWidth,
+      width: 1,
       pitch,
       velocity: defaultVelocity
     };
@@ -81,12 +79,7 @@ canvas.addEventListener('mousemove', (e) => {
   const { x, y } = getMousePos(e);
   if (mode === 'new' || mode === 'resize') {
     if (durationLayer.checked) {
-      let width = Math.max(1, x - currentNote.x);
-      if (discreteTime.checked) {
-        const step = currentBeatWidth / 4;
-        width = Math.max(step, Math.round(width / step) * step);
-      }
-      currentNote.width = width;
+      currentNote.width = Math.max(1, x - currentNote.x);
     }
   } else if (mode === 'move') {
     currentNote.x = x - dragOffsetX;
@@ -137,7 +130,6 @@ tempoSlider.addEventListener('input', () => {
 pitchLayer.addEventListener('change', updateControls);
 durationLayer.addEventListener('change', updateControls);
 loudnessLayer.addEventListener('change', updateControls);
-discreteTime.addEventListener('change', updateControls);
 
 playBtn.addEventListener('click', () => {
   if (isPlaying) {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
     <label><input type="checkbox" id="pitchLayer" checked /> Pitch</label>
     <label><input type="checkbox" id="durationLayer" checked /> Duration</label>
     <label><input type="checkbox" id="loudnessLayer" checked /> Loudness</label>
-    <label><input type="checkbox" id="discreteTime" checked /> Discrete Time</label>
     <label style="margin-left:10px;">Loudness
       <input type="range" id="velocity" min="1" max="127" value="100" />
     </label>


### PR DESCRIPTION
## Summary
- remove discrete time toggle and associated logic to restore continuous note durations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c19bdd221c83209f29ee7bf9d9c6f4